### PR TITLE
Guard against a Non-existant queue

### DIFF
--- a/linehaul/core.py
+++ b/linehaul/core.py
@@ -45,6 +45,7 @@ class LinehaulProtocol(SyslogProtocol):
     transport = None
     ensurer = None
     sender = None
+    queue = None
 
     def __init__(self, *args, bigquery, **kwargs):
         self.bigquery = bigquery
@@ -58,7 +59,8 @@ class LinehaulProtocol(SyslogProtocol):
         )
 
     async def _ensure_sender(self):
-        if self.sender is None or self.sender.done():
+        if (self.queue is not None and
+                (self.sender is None or self.sender.done())):
             self.sender = asyncio.ensure_future(
                 send(self.bigquery, self.queue, loop=self.loop),
                 loop=self.loop,


### PR DESCRIPTION
The ensure_sender coroutine can be called *prior* to the connection
being made. In this case we want to just skip out on trying to set up
a sender, because we won't yet have a queue for it to consume.