### PR TITLE
Stop logging unknown UAs to Sentry

### DIFF
--- a/linehaul/cli.py
+++ b/linehaul/cli.py
@@ -53,13 +53,11 @@ __version__ = raven.fetch_package_version("linehaul")
 )
 @click.option("--metrics-port", type=int, default=12000)
 @click.option("--sentry-dsn")
-@click.option("--sentry-ua-dsn")
 @click.option("--log-file")
 @click.argument("table", envvar="BIGQUERY_TABLE")
 @click.pass_context
 async def main(ctx, bind, port, token, account, key, reuse_port, tls_ciphers,
-               tls_certificate, metrics_port, sentry_dsn, sentry_ua_dsn,
-               log_file, table):
+               tls_certificate, metrics_port, sentry_dsn, log_file, table):
     # Configure logging
     target_logger = "logfile" if log_file else "console"
     logging.config.dictConfig({
@@ -92,12 +90,6 @@ async def main(ctx, bind, port, token, account, key, reuse_port, tls_ciphers,
                 "dsn": sentry_dsn,
                 "release": __version__,
             },
-            "ua_sentry": {
-                "level": "ERROR",
-                "class": "raven.handlers.logging.SentryHandler",
-                "dsn": sentry_ua_dsn,
-                "release": __version__,
-            },
         },
 
         "loggers": {
@@ -107,7 +99,7 @@ async def main(ctx, bind, port, token, account, key, reuse_port, tls_ciphers,
                 "propagate": False,
             },
             "linehaul.user_agents": {
-                "handlers": [target_logger, "ua_sentry"],
+                "handlers": [target_logger],
                 "level": "DEBUG",
                 "propagate": False,
             },

--- a/linehaul/core.py
+++ b/linehaul/core.py
@@ -86,13 +86,7 @@ class LinehaulProtocol(SyslogProtocol):
         try:
             download = parser.parse(message.message)
         except UnknownUserAgentError as exc:
-            ua_logger.error(
-                "Unknown UserAgent: %s", str(exc),
-                extra={
-                    "fingerprint": ["{{ default }}", str(exc)],
-                    "data": {"message": message},
-                },
-            )
+            ua_logger.error("Unknown UserAgent: %s", str(exc))
             return
         except Exception as exc:
             logger.exception(str(exc), extra={"data": {"message": message}})


### PR DESCRIPTION
It turns out that sentry is not a particularly great data store for
our unknown User Agents. Since I haven't been looking at this list
recently, and the inclusion of them is preventing other projects from
getting meaningful data out of Sentry, we're going to just stop doing
that.

Eventually we should re-add some mechanism for tracking what unknown
UAs we're getting so that we can correctly handle them.