### PR TITLE
fix default typo in ci attrib

### DIFF
--- a/linehaul/ua/datastructures.py
+++ b/linehaul/ua/datastructures.py
@@ -63,4 +63,4 @@ class UserAgent:
     cpu = attr.ib(type=Optional[str], default=None)
     openssl_version = attr.ib(type=Optional[str], default=None)
     setuptools_version = attr.ib(type=Optional[str], default=None)
-    ci = attr.ib(type=Optional[bool], defualt=None)
+    ci = attr.ib(type=Optional[bool], default=None)


### PR DESCRIPTION
BigQuery table hasn't updated since 4-25. Assuming this is the cause. Can you confirm?